### PR TITLE
fix: exclude irrelevant files from publishing to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "web-component",
     "polymer"
   ],
+  "files": [
+    "src",
+    "theme"
+  ],  
   "scripts": {
     "test": "wct",
     "lint": "eslint src/*.js",


### PR DESCRIPTION
For some reason, Flow fails in Vaadin 22 because it picks up the webpack config from the addon somehow.
Changed to only publish `src` and `theme` folders (README and LICENSE are always published).